### PR TITLE
Adding dependency on dtc/grid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "dtc/grid": "dev-master"
     },
     "require-dev": {
         "pda/pheanstalk": "dev-master",


### PR DESCRIPTION
This dependency is required as within the class "Dtc\QueueBundle\Grid\JobGridSource" it is extended of from "Dtc\GridBundle\Grid\Source\DocumentGridSource".